### PR TITLE
feat:Modification to existing revive system Revive Timer

### DIFF
--- a/client/job.lua
+++ b/client/job.lua
@@ -101,9 +101,10 @@ RegisterNetEvent('hospital:client:CheckStatus', function()
 end)
 
 
-local reviveDuration = sharedConfig.reviveDuration
+local reviveDuration = config.reviveDuration
 ---Get the length of time it takes to revive someone from the config.
 local function getReviveDur()
+	lib.print.error("getReviveDur called")
 	local duration = reviveDuration.default
 	if QBX.PlayerData.job.type == 'ems' and job.onduty then -- If you are an On Duty EMS
 		local jobGrade = QBX.PlayerData.job.grade.level -- Get the number associated with your jobcode
@@ -112,6 +113,7 @@ local function getReviveDur()
 		end
 	end
 	
+	lib.print.error("reviveDur: " .. duration)
 	return duration
 end
 

--- a/client/job.lua
+++ b/client/job.lua
@@ -100,6 +100,20 @@ RegisterNetEvent('hospital:client:CheckStatus', function()
     showTreatmentMenu(status.injuries)
 end)
 
+local reviveDuration = sharedConfig.reviveDuration
+---Get the length of time it takes to revive someone from the config.
+local function getReviveDur()
+	local duration = reviveDuration.default
+	if QBX.PlayerData.job.type == 'ems' and QBX.PlayerData.job.onduty then -- If you are an On Duty EMS
+		local jobGrade = QBX.PlayerData.job.grade.level -- Get the number associated with your jobcode
+		if reviveDuration[jobGrade] then -- if your number is inside the config
+			duration = reviveDuration[jobGrade] -- assign the value
+		end
+	end
+	
+	return duration
+end
+
 ---Use first aid on nearest player to revive them.
 ---Intended to be invoked by client or server.
 RegisterNetEvent('hospital:client:RevivePlayer', function()
@@ -116,7 +130,7 @@ RegisterNetEvent('hospital:client:RevivePlayer', function()
     end
 
     if lib.progressCircle({
-            duration = 5000,
+            duration = getReviveDur(),
             position = 'bottom',
             label = locale('progress.revive'),
             useWhileDead = false,

--- a/client/job.lua
+++ b/client/job.lua
@@ -100,24 +100,6 @@ RegisterNetEvent('hospital:client:CheckStatus', function()
     showTreatmentMenu(status.injuries)
 end)
 
-
-local reviveDuration = config.reviveDuration
----Get the length of time it takes to revive someone from the config.
-local function getReviveDur()
-	lib.print.error("getReviveDur called")
-	local duration = reviveDuration.default
-	if QBX.PlayerData.job.type == 'ems' and job.onduty then -- If you are an On Duty EMS
-		local jobGrade = QBX.PlayerData.job.grade.level -- Get the number associated with your jobcode
-		if reviveDuration[jobGrade] then -- if your number is inside the config
-			duration = reviveDuration[jobGrade] -- assign the value
-		end
-	end
-	
-	lib.print.error("reviveDur: " .. duration)
-	return duration
-end
-
-
 ---Use first aid on nearest player to revive them.
 ---Intended to be invoked by client or server.
 RegisterNetEvent('hospital:client:RevivePlayer', function()
@@ -126,8 +108,7 @@ RegisterNetEvent('hospital:client:RevivePlayer', function()
         exports.qbx_core:Notify(locale('error.no_firstaid'), 'error')
         return
     end
-	
-	local reviveSpeed = getReviveDur()
+
     local player = GetClosestPlayer()
     if not player then
         exports.qbx_core:Notify(locale('error.no_player'), 'error')
@@ -135,7 +116,7 @@ RegisterNetEvent('hospital:client:RevivePlayer', function()
     end
 
     if lib.progressCircle({
-            duration = reviveSpeed,
+            duration = 5000,
             position = 'bottom',
             label = locale('progress.revive'),
             useWhileDead = false,

--- a/client/job.lua
+++ b/client/job.lua
@@ -100,6 +100,22 @@ RegisterNetEvent('hospital:client:CheckStatus', function()
     showTreatmentMenu(status.injuries)
 end)
 
+
+local reviveDuration = sharedConfig.reviveDuration
+---Get the length of time it takes to revive someone from the config.
+local function getReviveDur()
+	local duration = reviveDuration.default
+	if QBX.PlayerData.job.type == 'ems' and job.onduty then -- If you are an On Duty EMS
+		local jobGrade = QBX.PlayerData.job.grade.level -- Get the number associated with your jobcode
+		if reviveDuration[jobGrade] then -- if your number is inside the config
+			duration = reviveDuration[jobGrade] -- assign the value
+		end
+	end
+	
+	return duration
+end
+
+
 ---Use first aid on nearest player to revive them.
 ---Intended to be invoked by client or server.
 RegisterNetEvent('hospital:client:RevivePlayer', function()
@@ -108,7 +124,8 @@ RegisterNetEvent('hospital:client:RevivePlayer', function()
         exports.qbx_core:Notify(locale('error.no_firstaid'), 'error')
         return
     end
-
+	
+	local reviveSpeed = getReviveDur()
     local player = GetClosestPlayer()
     if not player then
         exports.qbx_core:Notify(locale('error.no_player'), 'error')
@@ -116,7 +133,7 @@ RegisterNetEvent('hospital:client:RevivePlayer', function()
     end
 
     if lib.progressCircle({
-            duration = 5000,
+            duration = reviveSpeed,
             position = 'bottom',
             label = locale('progress.revive'),
             useWhileDead = false,

--- a/client/laststand.lua
+++ b/client/laststand.lua
@@ -28,33 +28,3 @@ end)
 lib.callback.register('hospital:client:canHelp', function()
     return exports.qbx_medical:getLaststand() and exports.qbx_medical:getLaststandTime() <= 300
 end)
-
----@param targetId number playerId
-RegisterNetEvent('hospital:client:HelpPerson', function(targetId)
-    if GetInvokingResource() then return end
-    if lib.progressCircle({
-            duration = math.random(30000, 60000),
-            position = 'bottom',
-            label = locale('progress.revive'),
-            useWhileDead = false,
-            canCancel = true,
-            disable = {
-                move = false,
-                car = false,
-                combat = true,
-                mouse = false,
-            },
-            anim = {
-                dict = HealAnimDict,
-                clip = HealAnim,
-            },
-        })
-    then
-        ClearPedTasks(cache.ped)
-        exports.qbx_core:Notify(locale('success.revived'), 'success')
-        TriggerServerEvent('hospital:server:RevivePlayer', targetId)
-    else
-        ClearPedTasks(cache.ped)
-        exports.qbx_core:Notify(locale('error.canceled'), 'error')
-    end
-end)

--- a/config/client.lua
+++ b/config/client.lua
@@ -5,21 +5,4 @@ return {
     checkInHealTime = 20,    -- Time in seconds that it takes to be healed from the check-in system
     laststandTimer = 300,    -- Time in seconds that the laststand timer lasts
     aiHealTimer = 20,        -- How long it will take to be healed after checking in, in seconds
-	
-    reviveDuration = { -- Correspond job grade numbers to their Duration of time it takes to revive someone
-		default = 5000,
-		[0] = 4500, --Candidate
-		[1] = 4000, --Firefighter 1
-		[2] = 3500, --Firefighter 2
-		[3] = 3000, --Firefighter 3
-		[4] = 2000, --Engineer
-		[5] = 1750, --Paramedic
-		[6] = 1500, --Lieutenant
-		[7] = 1250, --Captain
-		[8] = 750,  --Battalion Chief
-		[9] = 750,  --Deputy District Chief
-		[10] = 750, --District Chief
-		[11] = 750, --High Command
-		[12] = 750, --Commissioner
-	},  
 }

--- a/config/client.lua
+++ b/config/client.lua
@@ -5,4 +5,21 @@ return {
     checkInHealTime = 20,    -- Time in seconds that it takes to be healed from the check-in system
     laststandTimer = 300,    -- Time in seconds that the laststand timer lasts
     aiHealTimer = 20,        -- How long it will take to be healed after checking in, in seconds
+	
+    reviveDuration = { -- Correspond job grade numbers to their Duration of time it takes to revive someone
+		default = 5000,
+		[0] = 4500, --Candidate
+		[1] = 4000, --Firefighter 1
+		[2] = 3500, --Firefighter 2
+		[3] = 3000, --Firefighter 3
+		[4] = 2000, --Engineer
+		[5] = 1750, --Paramedic
+		[6] = 1500, --Lieutenant
+		[7] = 1250, --Captain
+		[8] = 750,  --Battalion Chief
+		[9] = 750,  --Deputy District Chief
+		[10] = 750, --District Chief
+		[11] = 750, --High Command
+		[12] = 750, --Commissioner
+	},  
 }

--- a/config/shared.lua
+++ b/config/shared.lua
@@ -106,21 +106,5 @@ return {
             { label = "Medical Center", coords = vector3(361.88, -1410.51, 32.52) }, -- Central LS
         }
 		
-    },
-    reviveDuration = { -- Correspond job grade numbers to their Duration of time it takes to revive someone
-		default = 5000
-		[0] = 4500, --Candidate
-		[1] = 4000, --Firefighter 1
-		[2] = 3500, --Firefighter 2
-		[3] = 3000, --Firefighter 3
-		[4] = 2000, --Engineer
-		[5] = 1750, --Paramedic
-		[6] = 1500, --Lieutenant
-		[7] = 1250, --Captain
-		[8] = 750,  --Battalion Chief
-		[9] = 750,  --Deputy District Chief
-		[10] = 750, --District Chief
-		[11] = 750, --High Command
-		[12] = 750, --Commissioner
-	},        
+    },  
 }

--- a/config/shared.lua
+++ b/config/shared.lua
@@ -105,5 +105,22 @@ return {
             { label = "Medical Center", coords = vector3(-447.11, -341.41, 34.5) },  -- Mount Zonah
             { label = "Medical Center", coords = vector3(361.88, -1410.51, 32.52) }, -- Central LS
         }
+		
     },
+    reviveDuration = { -- Correspond job grade numbers to their Duration of time it takes to revive someone
+		default = 5000
+		[0] = 4500, --Candidate
+		[1] = 4000, --Firefighter 1
+		[2] = 3500, --Firefighter 2
+		[3] = 3000, --Firefighter 3
+		[4] = 2000, --Engineer
+		[5] = 1750, --Paramedic
+		[6] = 1500, --Lieutenant
+		[7] = 1250, --Captain
+		[8] = 750,  --Battalion Chief
+		[9] = 750,  --Deputy District Chief
+		[10] = 750, --District Chief
+		[11] = 750, --High Command
+		[12] = 750, --Commissioner
+	},        
 }

--- a/config/shared.lua
+++ b/config/shared.lua
@@ -1,8 +1,8 @@
-local GovernmentData = exports.ef_nexus:GetGovernmentData("EFEmergency")
+--local GovernmentData = exports.ef_nexus:GetGovernmentData("EFEmergency")
 
 return {
-    reviveCost = GovernmentData.ReviveCost,        -- Price patient has to pay when they're revived
-    checkInCost = GovernmentData.HospitalBillCost, -- Price for using the hospital check-in system
+    reviveCost = 10, --GovernmentData.ReviveCost,        -- Price patient has to pay when they're revived
+    checkInCost = 20, --GovernmentData.HospitalBillCost, -- Price for using the hospital check-in system
     minForCheckIn = 20,                            -- Minimum number of people with the ambulance job to prevent the check-in system from being used
 
     locations = {                                  -- Various interaction points
@@ -105,5 +105,22 @@ return {
             { label = "Medical Center", coords = vector3(-447.11, -341.41, 34.5) },  -- Mount Zonah
             { label = "Medical Center", coords = vector3(361.88, -1410.51, 32.52) }, -- Central LS
         }
+		
     },
+    reviveDuration = { -- Correspond job grade numbers to their Duration of time it takes to revive someone
+		default = 100000,
+		[0] = 80000, --Candidate
+		[1] = 60000, --Firefighter 1
+		[2] = 50000, --Firefighter 2
+		[3] = 40000, --Firefighter 3
+		[4] = 30000, --Engineer
+		[5] = 20000, --Paramedic
+		[6] = 10000, --Lieutenant
+		[7] = 8000, --Captain
+		[8] = 5000,  --Battalion Chief
+		[9] = 5000,  --Deputy District Chief
+		[10] = 5000, --District Chief
+		[11] = 5000, --High Command
+		[12] = 5000, --Commissioner
+	},  
 }

--- a/config/shared.lua
+++ b/config/shared.lua
@@ -105,6 +105,5 @@ return {
             { label = "Medical Center", coords = vector3(-447.11, -341.41, 34.5) },  -- Mount Zonah
             { label = "Medical Center", coords = vector3(361.88, -1410.51, 32.52) }, -- Central LS
         }
-		
-    },  
+    },
 }

--- a/config/shared.lua
+++ b/config/shared.lua
@@ -1,8 +1,8 @@
---local GovernmentData = exports.ef_nexus:GetGovernmentData("EFEmergency")
+local GovernmentData = exports.ef_nexus:GetGovernmentData("EFEmergency")
 
 return {
-    reviveCost = 10, --GovernmentData.ReviveCost,        -- Price patient has to pay when they're revived
-    checkInCost = 20, --GovernmentData.HospitalBillCost, -- Price for using the hospital check-in system
+    reviveCost = GovernmentData.ReviveCost,        -- Price patient has to pay when they're revived
+    checkInCost = GovernmentData.HospitalBillCost, -- Price for using the hospital check-in system
     minForCheckIn = 20,                            -- Minimum number of people with the ambulance job to prevent the check-in system from being used
 
     locations = {                                  -- Various interaction points


### PR DESCRIPTION
## Description

<!-- What does your pull request change? Why should it be merged? Does it fix an issue? -->
This is an enhancement to the existing revive system.

If you are EMS, you should be able to revive people a bit faster. This does that, where the default revival time is 100s, and based on your rank from "Not EMS"(Default) all the way to Commissioner, it gets faster. 


## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
                 (Note regarding this^^) Everfall's implementation does not translate 1:1 to QBX, I tested on a lot of commented out code, that SHOULDNT have affected anything. Everfalls QBX Medical made it impossible to revive people, but using logging, i was able to prove it worked. I saw the time decrease based on job grade with the onDuty flag.

- [x] My pull request fits the contribution guidelines & code conventions.
